### PR TITLE
fixed generate qsts endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,9 +22,14 @@ const systemExperimentRoute = require("./routes/systemExperiment");
 const labExperimentRoute = require("./routes/lab");
 const authRoutes = require("./routes/auth");
 const notificationRoutes = require("./routes/V2/notification");
+const generatedQuestionRoutes = require("./routes/V2/generated-questions")
 
-const { teacherPassport } = require("./services/initPassport");
-const { studentPassport } = require("./services/initPassport");
+const {
+    teacherPassport
+} = require("./services/initPassport");
+const {
+    studentPassport
+} = require("./services/initPassport");
 
 //passport  strategies
 require("./services/teacherPassport")(teacherPassport);
@@ -34,17 +39,28 @@ const app = express();
 // Swagger files
 const swaggerUi = require("swagger-ui-express");
 const swaggerFile = require("./swagger-output.json");
-const { morganMiddleware } = require("./middleware/morgan");
+const {
+    morganMiddleware
+} = require("./middleware/morgan");
 app.use(morganMiddleware);
 // Swagger for API documentation
 app.use("/doc", swaggerUi.serve, swaggerUi.setup(swaggerFile));
 
 //initialize passports
-app.use(teacherPassport.initialize({ userProperty: "user" }));
-app.use(studentPassport.initialize({ userProperty: "user" }));
+app.use(teacherPassport.initialize({
+    userProperty: "user"
+}));
+app.use(studentPassport.initialize({
+    userProperty: "user"
+}));
 
-app.use(express.json({ limit: "50mb" }));
-app.use(express.urlencoded({ limit: "50mb", extended: true }));
+app.use(express.json({
+    limit: "50mb"
+}));
+app.use(express.urlencoded({
+    limit: "50mb",
+    extended: true
+}));
 app.use(cors());
 
 app.use("/api/lab", labsetupRoute);
@@ -64,5 +80,6 @@ app.use("/api/v2/teachers", teachersV2Route);
 app.use("/api/v2/students", studentsV2Route);
 app.use("/api/v2/teachers/classes", teacherClassV2Route);
 app.use("/api/v2/notifications", notificationRoutes);
+app.use("/api/v2/ai/questions", generatedQuestionRoutes)
 
 module.exports = app;


### PR DESCRIPTION
Apparently something minor broke in a previous PR

This fix simply imports the routes of the question generation endpoint into the application middleware hence exposing the endpoint.

Endpoints have been tested and are functioning as expected